### PR TITLE
Improve compatibility in the 4.x GLControl

### DIFF
--- a/OpenTK.WinForms.TestForm/Form1.Designer.cs
+++ b/OpenTK.WinForms.TestForm/Form1.Designer.cs
@@ -315,6 +315,7 @@
 			this.glControl.Size = new System.Drawing.Size(379, 211);
 			this.glControl.TabIndex = 2;
 			this.glControl.Text = "glControl1";
+			this.glControl.Load += new System.EventHandler(this.glControl_Load);
 			// 
 			// Form1
 			// 

--- a/OpenTK.WinForms.TestForm/Form1.cs
+++ b/OpenTK.WinForms.TestForm/Form1.cs
@@ -28,10 +28,8 @@ namespace OpenTK.WinForms.TestForm
                 MessageBoxButtons.OK);
         }
 
-        protected override void OnLoad(EventArgs e)
+        private void glControl_Load(object? sender, EventArgs e)
         {
-            base.OnLoad(e);
-
             // Make sure that when the GLControl is resized or needs to be painted,
             // we update our projection matrix or re-render its contents, respectively.
             glControl.Resize += glControl_Resize;
@@ -51,7 +49,7 @@ namespace OpenTK.WinForms.TestForm
             glControl_Resize(glControl, EventArgs.Empty);
         }
 
-        private void glControl_Resize(object sender, EventArgs e)
+        private void glControl_Resize(object? sender, EventArgs e)
         {
             glControl.MakeCurrent();
 

--- a/OpenTK.WinForms/GLControl.cs
+++ b/OpenTK.WinForms/GLControl.cs
@@ -510,6 +510,45 @@ namespace OpenTK.WinForms
         #region WinForms event handlers
 
         /// <summary>
+        /// This private object is used as the reference for the 'Load' handler in
+        /// the Events collection, and is only needed if you use the 'Load' event.
+        /// </summary>
+        private static readonly object EVENT_LOAD = new object();
+
+        /// <summary>
+        /// An event hook, triggered when the control is created for the first time.
+        /// </summary>
+        [Category("Behavior")]
+        [Description("Occurs when the GLControl is first created.")]
+        public event EventHandler Load
+        {
+            add => Events.AddHandler(EVENT_LOAD, value);
+            remove => Events.RemoveHandler(EVENT_LOAD, value);
+        }
+
+        /// <summary>
+        /// Raises the CreateControl event.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        protected override void OnCreateControl()
+        {
+            base.OnCreateControl();
+
+            OnLoad(EventArgs.Empty);
+        }
+
+        /// <summary>
+        /// The Load event is fired before the control becomes visible for the first time.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        protected virtual void OnLoad(EventArgs e)
+        {
+            // There is no good way to explain this event except to say
+            // that it's just another name for OnControlCreated.
+            ((EventHandler)Events[EVENT_LOAD])?.Invoke(this, e);
+        }
+
+        /// <summary>
         /// This is raised by WinForms to paint this instance.
         /// </summary>
         /// <param name="e">A PaintEventArgs object that describes which areas

--- a/OpenTK.WinForms/GLControl.cs
+++ b/OpenTK.WinForms/GLControl.cs
@@ -451,7 +451,7 @@ namespace OpenTK.WinForms
             // Try walking the control tree to see if any ancestors are in DesignMode.
             for (Control control = this; control != null; control = control.Parent)
             {
-                if (control.Site.DesignMode)
+                if (control.Site != null && control.Site.DesignMode)
                     return true;
             }
 


### PR DESCRIPTION
- This includes (maybe?) a fix for the `Control.Site` null-reference issue some people have run into.  I can't reproduce it myself, so this simply adds an extra `null` check in hopes that that'll make the issue go away.

- This adds a `Load` event (and an overridable `OnLoad` method) for better backward-compatibility with the 3.x GLControl.  That control inherited `UserControl`, which wasn't necessary and which added in lots of irrelevant events; but it seems some people were dependent on its provided `Load` event, so I've added an equivalent `Load` event for backward-compatibility, based on the way the `Load` event is fired in `UserControl` itself.