### PR TITLE
Context property

### DIFF
--- a/OpenTK.WinForms/GLControl.cs
+++ b/OpenTK.WinForms/GLControl.cs
@@ -118,6 +118,11 @@ namespace OpenTK.WinForms
         }
 
         /// <summary>
+        /// Gets the <see cref="IGraphicsContext"/> instance that is associated with the <see cref="GLControl"/>.
+        /// </summary>
+        public IGraphicsContext Context => _nativeWindow.Context;
+
+        /// <summary>
         /// Gets or sets a value indicating whether or not this window is event-driven.
         /// An event-driven window will wait for events before updating/rendering. It is useful for non-game applications,
         /// where the program only needs to do any processing after the user inputs something.


### PR DESCRIPTION
As discussed on discord, this PR improves backward compatibility with the 3.x versions by adding the public "Context" property on the control.  
Based on [this documentation](https://opentk.net/api/OpenTK.GLControl.html#OpenTK_GLControl_Context).