### PR TITLE
Setup Nuke build

### DIFF
--- a/.nuke
+++ b/.nuke
@@ -1,0 +1,1 @@
+OpenTK.WinForms.sln

--- a/OpenTK.WinForms.sln
+++ b/OpenTK.WinForms.sln
@@ -11,12 +11,16 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OpenTK.WinForms.MultiContro
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OpenTK.WinForms.InputTest", "OpenTK.WinForms.InputTest\OpenTK.WinForms.InputTest.csproj", "{65839490-2DE7-4823-AC53-C210A805A982}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "_build", "build\_build.csproj", "{7F8678E7-2F0E-44B1-903D-80FBA892D6A0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7F8678E7-2F0E-44B1-903D-80FBA892D6A0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7F8678E7-2F0E-44B1-903D-80FBA892D6A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{95E422AB-9DC7-4E2A-B13F-A26A52EF1BBA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{95E422AB-9DC7-4E2A-B13F-A26A52EF1BBA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{95E422AB-9DC7-4E2A-B13F-A26A52EF1BBA}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/OpenTK.WinForms/OpenTK.WinForms.csproj
+++ b/OpenTK.WinForms/OpenTK.WinForms.csproj
@@ -6,6 +6,18 @@
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>8.0</LangVersion>
+    <!--Version info is filled by Nuke build-->
+    <Authors>Team OpenTK</Authors>
+    <Description>A WinForms control designed to wrap the OpenTK 4.x APIs.</Description>
+    <Copyright>Copyright (c) 2021 Team OpenTK</Copyright>
+    <Company>Team OpenTK</Company>
+    <PackageProjectUrl>https://github.com/opentk/GLControl</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/opentk/GLControl</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <PackageTags>OpenTK, GLControl</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,40 +1,33 @@
+# Release notes
 
-### 4.0.0-pre.6
+All notable changes are documented in this file.
 
-_March 4, 2021_
+## 4.0.0-pre.5
+- _March 4, 2021_
+- Add `Context` property for better backward compatibility with GLControl 3.x.
 
-  * Add `Context` property for better backward compatibility with GLControl 3.x.
+## 4.0.0-pre.4
+- _February 18, 2021_
+- Fix `Control.Site` null-reference bug.
+- Add `Load` event for better backward compatibility with GLControl 3.x.
+- Update simple test to demonstrate `Load` event.
 
-### 4.0.0-pre.5
+## 4.0.0-pre.3
+- _December 28, 2020_
+- Fix design-mode bugs.
 
-_February 18, 2021_
+## 4.0.0-pre.2
+- _December 22, 2020_
+- Add more example projects to show usage: Simple example, multi-control example, and raw-input example.
+- Fix more bugs.
 
-  * Fix `Control.Site` null-reference bug.
-  * Add `Load` event for better backward compatibility with GLControl 3.x.
-  * Update simple test to demonstrate `Load` event.
-
-### 4.0.0-pre.3
-
-_December 28, 2020_
-
-  * Fix design-mode bugs.
-
-### 4.0.0-pre.2
-
-_December 22, 2020_
-
-  * Add more example projects to show usage: Simple example, multi-control example, and raw-input example.
-  * Fix more bugs.
-
-### 4.0.0-pre.1
-
-_December 21, 2020_
-
-  * All-new WebForms.GLControl, rewritten from the ground up for OpenTK 4.x and .NET Core 3.x+.
-  * Support both WinForms input events and "native device" input events.
-  * API is mostly backward compatible with the old GLControl.
-  * Full support for the new WinForms Designer (VS2019).
-  * All methods and properties fully XML-documented.
-  * Example project to show its usage.
-  * Readme that includes detailed usage and documentation.
+## 4.0.0-pre.1
+- _December 21, 2020_
+- All-new WebForms.GLControl, rewritten from the ground up for OpenTK 4.x and .NET Core 3.x+.
+- Support both WinForms input events and "native device" input events.
+- API is mostly backward compatible with the old GLControl.
+- Full support for the new WinForms Designer (VS2019).
+- All methods and properties fully XML-documented.
+- Example project to show its usage.
+- Readme that includes detailed usage and documentation.
 

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,7 @@
+:; set -eo pipefail
+:; SCRIPT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
+:; ${SCRIPT_DIR}/build.sh "$@"
+:; exit $?
+
+@ECHO OFF
+powershell -ExecutionPolicy ByPass -NoProfile "%~dp0build.ps1" %*

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,69 @@
+[CmdletBinding()]
+Param(
+    [Parameter(Position=0,Mandatory=$false,ValueFromRemainingArguments=$true)]
+    [string[]]$BuildArguments
+)
+
+Write-Output "PowerShell $($PSVersionTable.PSEdition) version $($PSVersionTable.PSVersion)"
+
+Set-StrictMode -Version 2.0; $ErrorActionPreference = "Stop"; $ConfirmPreference = "None"; trap { Write-Error $_ -ErrorAction Continue; exit 1 }
+$PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
+
+###########################################################################
+# CONFIGURATION
+###########################################################################
+
+$BuildProjectFile = "$PSScriptRoot\build\_build.csproj"
+$TempDirectory = "$PSScriptRoot\\.tmp"
+
+$DotNetGlobalFile = "$PSScriptRoot\\global.json"
+$DotNetInstallUrl = "https://dot.net/v1/dotnet-install.ps1"
+$DotNetChannel = "Current"
+
+$env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 1
+$env:DOTNET_CLI_TELEMETRY_OPTOUT = 1
+$env:DOTNET_MULTILEVEL_LOOKUP = 0
+
+###########################################################################
+# EXECUTION
+###########################################################################
+
+function ExecSafe([scriptblock] $cmd) {
+    & $cmd
+    if ($LASTEXITCODE) { exit $LASTEXITCODE }
+}
+
+# If dotnet CLI is installed globally and it matches requested version, use for execution
+if ($null -ne (Get-Command "dotnet" -ErrorAction SilentlyContinue) -and `
+     $(dotnet --version) -and $LASTEXITCODE -eq 0) {
+    $env:DOTNET_EXE = (Get-Command "dotnet").Path
+}
+else {
+    # Download install script
+    $DotNetInstallFile = "$TempDirectory\dotnet-install.ps1"
+    New-Item -ItemType Directory -Path $TempDirectory -Force | Out-Null
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    (New-Object System.Net.WebClient).DownloadFile($DotNetInstallUrl, $DotNetInstallFile)
+
+    # If global.json exists, load expected version
+    if (Test-Path $DotNetGlobalFile) {
+        $DotNetGlobal = $(Get-Content $DotNetGlobalFile | Out-String | ConvertFrom-Json)
+        if ($DotNetGlobal.PSObject.Properties["sdk"] -and $DotNetGlobal.sdk.PSObject.Properties["version"]) {
+            $DotNetVersion = $DotNetGlobal.sdk.version
+        }
+    }
+
+    # Install by channel or version
+    $DotNetDirectory = "$TempDirectory\dotnet-win"
+    if (!(Test-Path variable:DotNetVersion)) {
+        ExecSafe { & $DotNetInstallFile -InstallDir $DotNetDirectory -Channel $DotNetChannel -NoPath }
+    } else {
+        ExecSafe { & $DotNetInstallFile -InstallDir $DotNetDirectory -Version $DotNetVersion -NoPath }
+    }
+    $env:DOTNET_EXE = "$DotNetDirectory\dotnet.exe"
+}
+
+Write-Output "Microsoft (R) .NET Core SDK version $(& $env:DOTNET_EXE --version)"
+
+ExecSafe { & $env:DOTNET_EXE build $BuildProjectFile /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet }
+ExecSafe { & $env:DOTNET_EXE run --project $BuildProjectFile --no-build -- $BuildArguments }

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+bash --version 2>&1 | head -n 1
+
+set -eo pipefail
+SCRIPT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
+
+###########################################################################
+# CONFIGURATION
+###########################################################################
+
+BUILD_PROJECT_FILE="$SCRIPT_DIR/build/_build.csproj"
+TEMP_DIRECTORY="$SCRIPT_DIR//.tmp"
+
+DOTNET_GLOBAL_FILE="$SCRIPT_DIR//global.json"
+DOTNET_INSTALL_URL="https://dot.net/v1/dotnet-install.sh"
+DOTNET_CHANNEL="Current"
+
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+export DOTNET_MULTILEVEL_LOOKUP=0
+
+###########################################################################
+# EXECUTION
+###########################################################################
+
+function FirstJsonValue {
+    perl -nle 'print $1 if m{"'"$1"'": "([^"]+)",?}' <<< "${@:2}"
+}
+
+# If dotnet CLI is installed globally and it matches requested version, use for execution
+if [ -x "$(command -v dotnet)" ] && dotnet --version &>/dev/null; then
+    export DOTNET_EXE="$(command -v dotnet)"
+else
+    # Download install script
+    DOTNET_INSTALL_FILE="$TEMP_DIRECTORY/dotnet-install.sh"
+    mkdir -p "$TEMP_DIRECTORY"
+    curl -Lsfo "$DOTNET_INSTALL_FILE" "$DOTNET_INSTALL_URL"
+    chmod +x "$DOTNET_INSTALL_FILE"
+
+    # If global.json exists, load expected version
+    if [[ -f "$DOTNET_GLOBAL_FILE" ]]; then
+        DOTNET_VERSION=$(FirstJsonValue "version" "$(cat "$DOTNET_GLOBAL_FILE")")
+        if [[ "$DOTNET_VERSION" == ""  ]]; then
+            unset DOTNET_VERSION
+        fi
+    fi
+
+    # Install by channel or version
+    DOTNET_DIRECTORY="$TEMP_DIRECTORY/dotnet-unix"
+    if [[ -z ${DOTNET_VERSION+x} ]]; then
+        "$DOTNET_INSTALL_FILE" --install-dir "$DOTNET_DIRECTORY" --channel "$DOTNET_CHANNEL" --no-path
+    else
+        "$DOTNET_INSTALL_FILE" --install-dir "$DOTNET_DIRECTORY" --version "$DOTNET_VERSION" --no-path
+    fi
+    export DOTNET_EXE="$DOTNET_DIRECTORY/dotnet"
+fi
+
+echo "Microsoft (R) .NET Core SDK version $("$DOTNET_EXE" --version)"
+
+"$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet
+"$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"

--- a/build/.editorconfig
+++ b/build/.editorconfig
@@ -1,0 +1,11 @@
+[*.cs]
+dotnet_style_qualification_for_field = false:warning
+dotnet_style_qualification_for_property = false:warning
+dotnet_style_qualification_for_method = false:warning
+dotnet_style_qualification_for_event = false:warning
+dotnet_style_require_accessibility_modifiers = never:warning
+
+csharp_style_expression_bodied_methods = true:silent
+csharp_style_expression_bodied_properties = true:warning
+csharp_style_expression_bodied_indexers = true:warning
+csharp_style_expression_bodied_accessors = true:warning

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Linq;
+using Nuke.Common;
+using Nuke.Common.CI;
+using Nuke.Common.CI.GitHubActions;
+using Nuke.Common.Execution;
+using Nuke.Common.Git;
+using Nuke.Common.IO;
+using Nuke.Common.ProjectModel;
+using Nuke.Common.Tooling;
+using Nuke.Common.Tools.DotNet;
+using Nuke.Common.Utilities.Collections;
+using Nuke.GitHub;
+using static Nuke.Common.EnvironmentInfo;
+using static Nuke.Common.IO.FileSystemTasks;
+using static Nuke.Common.IO.PathConstruction;
+using static Nuke.Common.Tools.DotNet.DotNetTasks;
+using static Nuke.Common.ChangeLog.ChangelogTasks;
+using static Nuke.GitHub.ChangeLogExtensions;
+using static Nuke.GitHub.GitHubTasks;
+
+[CheckBuildProjectConfigurations]
+[ShutdownDotNetAfterServerBuild]
+//TODO: configure CI
+//[GitHubActions("ci",
+//    GitHubActionsImage.WindowsLatest,
+//    AutoGenerate = true,
+//    //OnPushBranches = new[] { "master" },
+//    OnPullRequestBranches = new[] { "master" },
+//    InvokedTargets = new[] { nameof(GitHubActions) },
+//    ImportSecrets = new[] { "token" })]
+class Build : NukeBuild
+{
+    /// Support plugins are available for:
+    ///   - JetBrains ReSharper        https://nuke.build/resharper
+    ///   - JetBrains Rider            https://nuke.build/rider
+    ///   - Microsoft VisualStudio     https://nuke.build/visualstudio
+    ///   - Microsoft VSCode           https://nuke.build/vscode
+
+    public static int Main () => Execute<Build>(x => x.Compile);
+
+    [Parameter("Configuration to build - Default is 'Debug' (local) or 'Release' (server)")]
+    readonly Configuration Configuration = IsLocalBuild ? Configuration.Debug : Configuration.Release;
+
+    [Parameter("NuGet api key")]
+    readonly string NugetApiKey;
+
+    [Parameter("Github authentication token")]
+    readonly string GitHubAuthToken;
+
+    [Parameter("NuGet api url")]
+    readonly string NugetApiUrl = "https://api.nuget.org/v3/index.json";
+
+
+    //[Parameter("URL of the icon to be displayed for the package")]
+    readonly string packageIconUrl = "https://raw.githubusercontent.com/opentk/opentk.net/docfx/assets/opentk.png";
+
+    [Solution] readonly Solution Solution;
+    [GitRepository] readonly GitRepository GitRepository;
+
+    AbsolutePath ArtifactsDirectory => RootDirectory / "artifacts";
+    AbsolutePath ChangelogPath => RootDirectory / "RELEASE_NOTES.md";
+
+    //informations based on the changelog
+    private string releaseVersion;
+    private string assemblyVersion;
+    private string releaseNotes;
+
+    Target Clean => _ => _
+        .Before(Restore)
+        .Executes(() =>
+        {
+            RootDirectory.GlobDirectories("OpenTK**/bin", "OpenTK**/obj").ForEach(DeleteDirectory);
+            EnsureCleanDirectory(ArtifactsDirectory);
+        });
+
+    Target Restore => _ => _
+        .Executes(() =>
+        {
+            DotNetRestore(s => s
+                .SetProjectFile(Solution));
+        });
+
+    Target VersionInfo => _ => _
+        .Unlisted()
+        .Executes(() =>
+        {
+            Logger.Normal("Reading changelog...");
+
+            //Changelog.LatestVersion is taken from the end of the file, but ours is reversed.
+            var latest = ReadChangelog(ChangelogPath).ReleaseNotes.Last();//pick first in the file
+            releaseVersion = latest.Version.ToNormalizedString();//semver
+            assemblyVersion = latest.Version.Version.ToString();//strips suffix //TODO: technically this should be different for each prerelease too
+            releaseNotes = string.Join(Environment.NewLine, latest.Notes);
+
+            string channel = latest.Version.IsPrerelease ? "prerelease" : "stable";
+            Logger.Info($"Package version:\t{releaseVersion} ({channel})");
+            Logger.Info($"Assembly version:\t{assemblyVersion}");
+            Logger.Info($"Release notes:");
+            Logger.Normal(releaseNotes);
+        });
+
+    Target Compile => _ => _
+        .DependsOn(Restore, VersionInfo)
+        //.Requires(() => releaseVersion, () => assemblyVersion)
+        .Executes(() =>
+        {
+            DotNetBuild(s => s
+                .SetProjectFile(Solution)
+                .SetConfiguration(Configuration)
+                .SetVersion(releaseVersion)
+                .SetAssemblyVersion(assemblyVersion)
+                .EnableNoRestore());
+        });
+
+    Target Pack => _ => _
+        .DependsOn(VersionInfo)
+        //.DependsOn(Compile)//TODO: Enable this in a CI scenario
+        .Produces(ArtifactsDirectory / "*.nupkg")
+        //.Requires(() => releaseNotes, () => releaseVersion)
+        .Executes(() =>
+        {
+            var msbuildFormattedReleaseNotes = releaseNotes.EscapeStringPropertyForMsBuild();
+            DotNetPack(s => s
+                .SetProject(Solution.GetProject("OpenTK.WinForms"))
+                .SetConfiguration(Configuration)
+                //properties specific to this release:
+                .SetVersion(releaseVersion)
+                .SetAssemblyVersion(assemblyVersion)
+                .SetPackageReleaseNotes(msbuildFormattedReleaseNotes)
+                .SetCopyright($"Copyright (c) {DateTime.Now.Year} Team OpenTK")
+                //these can't be set in the .csproj:
+                .SetPackageIconUrl(packageIconUrl)
+                .SetIncludeSymbols(true)//this will produce 2 nupkgs, one with symbols and one with dll-only
+                //.SetIncludeSource(true)//set this to include source in the symbols package
+                //the rest of the properties are set once in the .csproj, such as project url, authors, ...
+                //TODO: Enable these in a CI scenario:
+                //.EnableNoRestore()
+                //.EnableNoBuild()
+                .SetOutputDirectory(ArtifactsDirectory));
+
+        });
+    
+    /// <summary>
+    /// Triggers all push targets at once after a clean.
+    /// </summary>
+    Target PublishRelease => _ => _
+        .DependsOn(Clean, Pack)
+        .Requires(() => Configuration.Equals(Configuration.Release))
+        .Triggers(PushNuget, PushGithub);
+
+    Target PushNuget => _ => _
+        .DependsOn(Pack)
+        .Requires(() => NugetApiUrl)
+        .Requires(() => NugetApiKey)
+        .Requires(() => Configuration.Equals(Configuration.Release))
+        .Executes(() =>
+        {
+            DotNetNuGetPush(s => s
+                .SetSource(NugetApiUrl)
+                .SetApiKey(NugetApiKey)
+                .EnableSkipDuplicate()//in case the artifacts folder was no cleaned
+                .CombineWith(
+                    ArtifactsDirectory.GlobFiles("*.symbols.nupkg").NotEmpty(), (cs, v) => cs
+                        .SetTargetPath(v)));
+        });
+
+    Target PushGithub => _ => _
+    .DependsOn(Pack, VersionInfo)
+    .Requires(() => GitHubAuthToken)
+    //.Requires(() => releaseVersion, () => releaseNotes)
+    .Requires(() => Configuration.Equals(Configuration.Release))
+    .Executes(() =>
+    {
+        var releaseTag =$"v{releaseVersion}";
+        var repositoryInfo = GetGitHubRepositoryInfo(GitRepository);
+        var nuGetPackages = GlobFiles(ArtifactsDirectory, "*.symbols.nupkg").NotEmpty().ToArray();
+
+        //Note: if the release is already present, nothing happens
+        GitHubTasks.PublishRelease(s => s
+            .SetToken(GitHubAuthToken)
+            .SetArtifactPaths(nuGetPackages)
+            .SetTag(releaseTag)
+            .SetReleaseNotes(releaseNotes)
+            .SetCommitSha(GitRepository.Commit)
+            .SetRepositoryName(repositoryInfo.repositoryName)
+            .SetRepositoryOwner(repositoryInfo.gitHubOwner)).Wait();
+
+    });
+
+}

--- a/build/Configuration.cs
+++ b/build/Configuration.cs
@@ -1,0 +1,16 @@
+using System;
+using System.ComponentModel;
+using System.Linq;
+using Nuke.Common.Tooling;
+
+[TypeConverter(typeof(TypeConverter<Configuration>))]
+public class Configuration : Enumeration
+{
+    public static Configuration Debug = new Configuration { Value = nameof(Debug) };
+    public static Configuration Release = new Configuration { Value = nameof(Release) };
+
+    public static implicit operator string(Configuration configuration)
+    {
+        return configuration.Value;
+    }
+}

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RootNamespace></RootNamespace>
+    <NoWarn>CS0649;CS0169</NoWarn>
+    <NukeRootDirectory>..</NukeRootDirectory>
+    <NukeScriptDirectory>..</NukeScriptDirectory>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Nuke.Common" Version="5.0.2" />
+    <PackageReference Include="Nuke.GitHub" Version="2.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/build/_build.csproj.DotSettings
+++ b/build/_build.csproj.DotSettings
@@ -1,0 +1,26 @@
+<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=HeapView_002EDelegateAllocation/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=VariableHidesOuterVariable/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ClassNeverInstantiated_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MemberCanBeMadeStatic_002ELocal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/DEFAULT_INTERNAL_MODIFIER/@EntryValue">Implicit</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/DEFAULT_PRIVATE_MODIFIER/@EntryValue">Implicit</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/METHOD_OR_OPERATOR_BODY/@EntryValue">ExpressionBody</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/ThisQualifier/INSTANCE_MEMBERS_QUALIFY_MEMBERS/@EntryValue">0</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ANONYMOUS_METHOD_DECLARATION_BRACES/@EntryValue">NEXT_LINE</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_USER_LINEBREAKS/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_AFTER_INVOCATION_LPAR/@EntryValue">False</s:Boolean>
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/MAX_ATTRIBUTE_LENGTH_FOR_SAME_LINE/@EntryValue">120</s:Int64>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_FIELD_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">IF_OWNER_IS_SINGLE_LINE</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_ARGUMENTS_STYLE/@EntryValue">WRAP_IF_LONG</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_SIMPLE_ANONYMOUSMETHOD_ON_SINGLE_LINE/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpAttributeForSingleLineMethodUpgrade/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpRenamePlacementToArrangementMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/publish.cmd
+++ b/publish.cmd
@@ -1,0 +1,3 @@
+REM clean, restore, compile, pack, then publish to nuget and github
+cls
+.\build.cmd --target PublishRelease --configuration release


### PR DESCRIPTION
Maintainers can use `publish.cmd`, Nuke will ask for a nuget key and a github key and it will publish a new release based on release_notes.md as requested on discord.  
There's also the option to do the same without publishing, good for testing the package locally:  
 `.\build.cmd --target pack --configuration release`

Artifacts are produced in the `artifacts` folder, already gitignored.
I've left some todo comments for a future CI possibility.